### PR TITLE
feat(page-props): PageProps機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+#### 0.0.8 (2019-01-02)
+
+##### New Features
+
+* **custom-template-params:**  add page props ([6ffa18bd](https://github.com/Himenon/rocu/commit/6ffa18bd9609f3dfbf157f4afbc551620b8b1315))
+
+##### Bug Fixes
+
+* **bags:**  fix some bags ([394a412d](https://github.com/Himenon/rocu/commit/394a412dce5dd6194c8c72d369201f28054fe757))
+* **typing:**  export typing files ([971c9238](https://github.com/Himenon/rocu/commit/971c9238888c571c9b832fcd4419fb7325858745))
+* **path:**  skip add base path when path started http:// or https:// ([3dece6dc](https://github.com/Himenon/rocu/commit/3dece6dc96eef3287cb570048fe076890ff2bc48))
+
 #### 0.0.7 (2019-01-02)
 
 ##### New Features

--- a/CustomTemplate/template.js
+++ b/CustomTemplate/template.js
@@ -1,4 +1,6 @@
 "use strict";
+// tslint:disable-next-line:no-reference
+/// <reference path="../typings/@rocu/index.d.ts"/>
 Object.defineProperty(exports, "__esModule", { value: true });
 const React = require("react");
 const wrappedContent = (content) => {
@@ -6,5 +8,7 @@ const wrappedContent = (content) => {
 };
 exports.bodyTemplate = (props) => (content) => {
     const newContent = wrappedContent(content);
-    return React.createElement("body", { id: "custom-template" }, newContent);
+    return (React.createElement("body", { id: "custom-template" },
+        React.createElement("h1", null, props.site.title),
+        newContent));
 };

--- a/CustomTemplate/template.js
+++ b/CustomTemplate/template.js
@@ -10,5 +10,6 @@ exports.bodyTemplate = (props) => (content) => {
     const newContent = wrappedContent(content);
     return (React.createElement("body", { id: "custom-template" },
         React.createElement("h1", null, props.site.title),
+        React.createElement("pre", null, JSON.stringify(props, null, 2)),
         newContent));
 };

--- a/CustomTemplate/template.tsx
+++ b/CustomTemplate/template.tsx
@@ -1,10 +1,19 @@
+// tslint:disable-next-line:no-reference
+/// <reference path="../typings/@rocu/index.d.ts"/>
+
+import { PageProps } from "@rocu/page";
 import * as React from "react";
 
 const wrappedContent = (content?: React.ReactNode): React.ReactElement<any> => {
   return <div id="content">{content}</div>;
 };
 
-export const bodyTemplate = (props: any) => (content?: React.ReactNode): React.ReactElement<any> => {
+export const bodyTemplate = (props: PageProps) => (content?: React.ReactNode): React.ReactElement<any> => {
   const newContent = wrappedContent(content);
-  return <body id="custom-template">{newContent}</body>;
+  return (
+    <body id="custom-template">
+      <h1>{props.site.title}</h1>
+      {newContent}
+    </body>
+  );
 };

--- a/CustomTemplate/template.tsx
+++ b/CustomTemplate/template.tsx
@@ -13,6 +13,7 @@ export const bodyTemplate = (props: PageProps) => (content?: React.ReactNode): R
   return (
     <body id="custom-template">
       <h1>{props.site.title}</h1>
+      <pre>{JSON.stringify(props, null, 2)}</pre>
       {newContent}
     </body>
   );

--- a/example/rocu.json
+++ b/example/rocu.json
@@ -1,6 +1,7 @@
 {
   "global": {
     "lang": "ja",
+    "title": "example site",
     "keywords": "static site generator,NodeJS,React",
     "copyright": "@Himenon",
     "viewport": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocu",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Static Site Generator",
   "keywords": [
     "template",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Himenon",
   "files": [
     "lib",
+    "typings",
     "package.json"
   ],
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rocu",
   "version": "0.0.7",
-  "description": "Frontend Performance Tool",
+  "description": "Static Site Generator",
   "keywords": [
     "template",
     "typescript"

--- a/src/__tests__/getLayout.test.tsx
+++ b/src/__tests__/getLayout.test.tsx
@@ -5,6 +5,24 @@ import * as ReactDOM from "react-dom/server";
 import { createTemplate } from "../createTemplate";
 
 describe("rendering test", () => {
+  const pageProps: PageProps = {
+    site: {
+      title: "",
+      description: "",
+      url: {
+        relativePath: "",
+        absolutePath: "",
+      },
+    },
+    article: {
+      title: "",
+      description: "",
+      url: {
+        relativePath: "",
+        absolutePath: "",
+      },
+    },
+  };
   test("Component", () => {
     // tslint:disable-next-line:variable-name
     const Component = class extends React.Component<{ name: string }, {}> {
@@ -17,7 +35,7 @@ describe("rendering test", () => {
   });
 
   test("createTemplate", () => {
-    const wrapper = createTemplate();
+    const wrapper = createTemplate({ pageProps });
     const element = wrapper(<div>{"hello"}</div>);
     const result = ReactDOM.renderToStaticMarkup(element);
     expect(result).toBe("<body><div>hello</div></body>");
@@ -32,7 +50,7 @@ describe("rendering test", () => {
       );
     };
     const wrapper = createTemplate({
-      pageProps: {},
+      pageProps,
       applyLayout,
     });
     const element = wrapper(<div>{"hello"}</div>);

--- a/src/__tests__/getPage.test.ts
+++ b/src/__tests__/getPage.test.ts
@@ -1,0 +1,15 @@
+jest.unmock("../getPage");
+import { isStartWithHttp } from "../getPage";
+
+describe("getPage test", () => {
+  test("isStartWithHttp", () => {
+    expect(isStartWithHttp("//example.com")).toBe(true);
+    expect(isStartWithHttp("http://example.com")).toBe(true);
+    expect(isStartWithHttp("https://example.com")).toBe(true);
+    expect(isStartWithHttp("/example.com")).toBe(false);
+    expect(isStartWithHttp("http//example.com")).toBe(false);
+    expect(isStartWithHttp("https//example.com")).toBe(false);
+    expect(isStartWithHttp("http/example.com")).toBe(false);
+    expect(isStartWithHttp("https/example.com")).toBe(false);
+  });
+});

--- a/src/createTemplate.tsx
+++ b/src/createTemplate.tsx
@@ -13,9 +13,7 @@ export const createTemplateComponent = (props: TemplateProps) => {
   };
 };
 
-export const createTemplate = (props: TemplateProps = { pageProps: {} }) => (
-  bodyContent: React.ReactElement<any>,
-): React.ReactElement<any> => {
+export const createTemplate = (props: TemplateProps) => (bodyContent: React.ReactElement<any>): React.ReactElement<any> => {
   // tslint:disable-next-line:variable-name
   const Template = createTemplateComponent(props);
   return <Template children={bodyContent} />;

--- a/src/generateProps.ts
+++ b/src/generateProps.ts
@@ -1,0 +1,24 @@
+import { CommonOption } from "@rocu/cli";
+import { ArticleProps, PageElement, SiteProps } from "@rocu/page";
+
+export const generateSiteProps = (option: CommonOption): SiteProps => {
+  return {
+    title: option.global.title || "",
+    description: option.global.description || "",
+    url: {
+      relativePath: option.serverBasePath || "",
+      absolutePath: "",
+    },
+  };
+};
+
+export const generateArticleProps = (page: PageElement): ArticleProps => {
+  return {
+    title: page.metaData.title || "",
+    description: page.metaData.description || "",
+    url: {
+      relativePath: page.uri,
+      absolutePath: "",
+    },
+  };
+};

--- a/src/getPage.ts
+++ b/src/getPage.ts
@@ -7,19 +7,21 @@ import { HtmlMetaProperties, LinkHTMLAttributes, PageElement, ScriptHTMLAttribut
 import * as recursive from "recursive-readdir";
 import { getDefaultConfig } from "./helpers";
 
+const isStartWithHttp = (url: string): boolean => !!url.match(/^https?\:\/\//);
+
 const rewriteScriptSource = (attribute: string | ScriptHTMLAttributes, basePath: string): string | ScriptHTMLAttributes => {
   if (typeof attribute === "string") {
-    return path.join(basePath, attribute);
+    return isStartWithHttp(attribute) ? attribute : path.join(basePath, attribute);
   }
-  const src = attribute.src ? path.join(basePath, attribute.src) : undefined;
+  const src = attribute.src ? (isStartWithHttp(attribute.src) ? attribute.src : path.join(basePath, attribute.src)) : undefined;
   return { ...attribute, src };
 };
 
 const rewriteLinkSource = (attribute: string | LinkHTMLAttributes, basePath: string): string | LinkHTMLAttributes => {
   if (typeof attribute === "string") {
-    return path.join(basePath, attribute);
+    return isStartWithHttp(attribute) ? attribute : path.join(basePath, attribute);
   }
-  const href = attribute.href ? path.join(basePath, attribute.href) : undefined;
+  const href = attribute.href ? (isStartWithHttp(attribute.href) ? attribute.href : path.join(basePath, attribute.href)) : undefined;
   return { ...attribute, href };
 };
 

--- a/src/getPage.ts
+++ b/src/getPage.ts
@@ -7,7 +7,7 @@ import { HtmlMetaProperties, LinkHTMLAttributes, PageElement, ScriptHTMLAttribut
 import * as recursive from "recursive-readdir";
 import { getDefaultConfig } from "./helpers";
 
-const isStartWithHttp = (url: string): boolean => !!url.match(/^https?\:\/\//);
+export const isStartWithHttp = (url: string): boolean => url.match(/^https?\:\/\/|^\/\//) !== null;
 
 const rewriteScriptSource = (attribute: string | ScriptHTMLAttributes, basePath: string): string | ScriptHTMLAttributes => {
   if (typeof attribute === "string") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
 export { generateStaticPages } from "./generator";
 export { notifyLog } from "./logger";
 export { server } from "./server";
+/**
+ * Type Files
+ */
+export * from "@rocu/cli";
+export * from "@rocu/development";
+export * from "@rocu/component";
+export * from "@rocu/page";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,4 @@ export { server } from "./server";
  */
 export * from "@rocu/cli";
 export * from "@rocu/development";
-export * from "@rocu/component";
 export * from "@rocu/page";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,3 @@
 export { generateStaticPages } from "./generator";
 export { notifyLog } from "./logger";
 export { server } from "./server";
-/**
- * Type Files
- */
-export * from "@rocu/cli";
-export * from "@rocu/development";
-export * from "@rocu/page";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -12,6 +12,7 @@ import { RenderedStaticPage } from "@rocu/page";
 import { lookup } from "mime-types";
 import { generateStatic } from "../generator";
 import { getData } from "../getPage";
+import { getDefaultConfig } from "../helpers";
 import { reloadScript } from "./reloadScript";
 import { makeWebSocketServer } from "./wsServer";
 
@@ -69,6 +70,11 @@ const start = async (dirname: string, option: DevelopOption) => {
   const update = async (updateParams: { filename: string }) => {
     if (!socket) {
       return;
+    }
+    // TODO Side Effectを解消する
+    if (path.join(dirname, "rocu.json") === updateParams.filename) {
+      const updateConfig = getDefaultConfig(dirname);
+      option = { ...option, ...updateConfig };
     }
     const updatedSource = await getData(dirname, { ...option, watcher: updateParams });
     generatedPages = await generateStatic(updatedSource, option);

--- a/src/transformer/tags/helpers.ts
+++ b/src/transformer/tags/helpers.ts
@@ -9,7 +9,7 @@ import * as path from "path";
  */
 export const rewriteUrl = (uri: string, page: PageElement, option: CommonOption): string => {
   let calcUri: string = uri;
-  if (uri.match(/^https?\:\/\//)) {
+  if (uri.match(/^https?\:\/\/|^\/\//) !== null) {
     return uri;
   }
   if (uri.endsWith("index")) {

--- a/typings/@rocu/index.d.ts
+++ b/typings/@rocu/index.d.ts
@@ -36,12 +36,6 @@ declare module "@rocu/cli" {
   }
 }
 
-declare module "@rocu/component" {
-  export type ElementNames = keyof JSX.IntrinsicElements;
-  export type Component = {};
-  export type Option = {};
-}
-
 declare module "@rocu/page" {
   export interface TwitterMeta {
     "twitter:card"?: "summary" | "summary_large_image";
@@ -104,7 +98,28 @@ declare module "@rocu/page" {
     applyLayout?: makeTemplateFunc;
   }
 
-  export interface PageProps {}
+  export interface SiteProps {
+    title: string;
+    description: string;
+    url: {
+      relativePath: string;
+      absolutePath: string;
+    };
+  }
+
+  export interface ArticleProps {
+    title: string;
+    description: string;
+    url: {
+      relativePath: string;
+      absolutePath: string;
+    };
+  }
+
+  export interface PageProps {
+    site: SiteProps;
+    article: ArticleProps;
+  }
 
   export interface PageElement {
     uri: string;


### PR DESCRIPTION
## これはなに

* [x] 各ページにサイトのPropsを渡せるように

Bug Fix

* metaタグ中の`//`や`https?`から始まるURLのときにエスケープされない。
* `typings/`以下がパッケージに含まれていない

## どのように解決するか

* [ ] Bという解決方法を取った

## 確認事項

* [ ] 自己レビューした
* [ ] CIが通った

## バージョン

* [ ] Major: 後方互換性のない変更を含む
* [ ] Minor: 後方互換性があり機能を追加した
* [ ] Patch: 後方互換性があり、新規実装を含まないバグ修正を行った

Ref: [セマンティック バージョニング](https://semver.org/lang/ja/)
